### PR TITLE
#1: Clean CSRF cookie on logout (closes #1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ ADD entrypoint.sh /
 ADD nginx.conf.template .
 
 ENV COOKIE_NAME _forward_auth
+ENV CSRF_COOKIE_NAME _forward_auth_csrf
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,6 @@ urlencode() {
 
 RETURN_TO=$(urlencode $RETURN_TO)
 
-envsubst '\$COOKIE_NAME \$AUTH0_TENANT \$AUTH0_CLIENT_ID' < ./nginx.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '\$COOKIE_NAME \$CSRF_COOKIE_NAME \$AUTH0_TENANT \$AUTH0_CLIENT_ID' < ./nginx.conf.template > /etc/nginx/conf.d/default.conf
 
 exec nginx -g 'daemon off;'

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -3,6 +3,7 @@ server {
 
   location = /logout {
       add_header Set-Cookie "${COOKIE_NAME}=; Domain=.$host; Path=/; Expires=Thu, 01-Jan-1970 00:00:01 GMT;";
+      add_header Set-Cookie "${CSRF_COOKIE_NAME}=; Domain=.$host; Path=/; Expires=Thu, 01-Jan-1970 00:00:01 GMT;";
       rewrite ^ https://${AUTH0_TENANT}.auth0.com/v2/logout?client_id=${AUTH0_CLIENT_ID}&returnTo=https://$host permanent;
     }
 }


### PR DESCRIPTION
Closes [#2520566](https://buildo.kaiten.io/space/32111/card/2520566)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #1

## Test Plan

### tests performed

Tested locally. Seems to work fine